### PR TITLE
Proposed bug fix for Windows machines

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function processFileContentsForBlock(
   for(i = 0; i < lines.length; i++) {
     var line = lines[i];
 
-    if(line === endBlockComment) {
+    if(line.indexOf(endBlockComment) >= 0) {
      inBlock = false;
     }
 
@@ -75,8 +75,8 @@ function processFileContentsForBlock(
       }
     }
 
-    if(line === startBlockComment || line === endBlockComment) {
-      inBlock = line === startBlockComment;
+    if((line.indexOf(startBlockComment) >= 0) || (line.indexOf(endBlockComment) >= 0)) {
+      inBlock = (line.indexOf(startBlockComment) >= 0);
     }
   }
 


### PR DESCRIPTION
Windows paths have the \r\n so when lines are split into an array using \n there's a remaining \r. Comparing to the startBlockComment or endBlockComment fails. If you use string.indexOf() then it doesn't matter what the line delimiters are and you don't care if the user accidentally added spaces before or after the <!-- dev -->.